### PR TITLE
bash_profile: comment out export path

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -7,8 +7,8 @@ case "$OSTYPE" in
     #
   ;;
   linux*)
-    export PATH="$HOME/.parts/autoparts/bin:$PATH"
-    eval "$(parts init -)"
+    # export PATH="$HOME/.parts/autoparts/bin:$PATH"
+    # eval "$(parts init -)"
   ;;
 esac
 


### PR DESCRIPTION
Can't remember, but I think this came from Nitrous. Export is
giving me an error in devenv.